### PR TITLE
Select Option is "selected" based on value or default value

### DIFF
--- a/src/views/fields/select_option.blade.php
+++ b/src/views/fields/select_option.blade.php
@@ -1,1 +1,1 @@
-<option	value="{{ $key }}"{{ ($Field->attributes->value == $key || $Field->default_value == $key ? ' selected' : '') }}{{ (is_array($Field->attributes->value) && in_array($key, $Field->attributes->value) ? ' selected' : '') }}>{{ $value }}</option>
+<option	value="{{ $key }}"{{ ($Field->attributes->value == $key || ($Field->default_value == $key && !$Field->attributes->value)? ' selected' : '') }}{{ (is_array($Field->attributes->value) && in_array($key, $Field->attributes->value) ? ' selected' : '') }}>{{ $value }}</option>


### PR DESCRIPTION
This pull request is for issue [20](https://github.com/nickwest/EloquentForms/issues/20)

In the original code, the select option was checking if the key matched the field's value or default value. This resulted in both the field's value and default value having the "selected" attribute.

Now, the select option checks if the key matches the value, or matches the default value if no value was provided, fixing the multiple options having the selected attribute in a single select issue. 